### PR TITLE
prepare 2.1.1 release

### DIFF
--- a/src/main/java/com/launchdarkly/sdk/ContextBuilder.java
+++ b/src/main/java/com/launchdarkly/sdk/ContextBuilder.java
@@ -380,8 +380,8 @@ public final class ContextBuilder {
     anonymous = context.isAnonymous();
     attributes = context.attributes;
     privateAttributes = context.privateAttributes;
-    copyOnWriteAttributes = true;
-    copyOnWritePrivateAttributes = true;
+    copyOnWriteAttributes = context.attributes != null;
+    copyOnWritePrivateAttributes = context.privateAttributes != null;
     return this;
   }
   

--- a/src/test/java/com/launchdarkly/sdk/ContextBuilderTest.java
+++ b/src/test/java/com/launchdarkly/sdk/ContextBuilderTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @SuppressWarnings("javadoc")
@@ -130,5 +131,15 @@ public class ContextBuilderTest {
         assertThat(c2, equalTo(c1));
       }
     }
+  }
+
+  @Test
+  public void doesNotThrowNPEWhenReusingContext() {
+    LDContext initialContext = LDContext.builder("123456").build();
+    LDContext downstreamContext = LDContext.builderFromContext(initialContext)
+            .set("some_attribute", "someValue")
+            .build();
+
+    assertThat(downstreamContext, notNullValue());
   }
 }


### PR DESCRIPTION
## [2.1.1] - 2023-11-13
### Fixed:
- Fixes NPE when interacting with Context created by use of `copyFrom`.  (Thanks, [
pedroafonsodias](https://github.com/launchdarkly/java-sdk-common/pull/15))